### PR TITLE
feat: mypage 기능 구현

### DIFF
--- a/src/main/java/com/example/community/controller/UserController.java
+++ b/src/main/java/com/example/community/controller/UserController.java
@@ -2,6 +2,7 @@ package com.example.community.controller;
 
 import com.example.community.dto.LoginRequestDto;
 import com.example.community.dto.LoginResponseDto;
+import com.example.community.dto.MyPageResponseDto;
 import com.example.community.dto.UserRequestDto;
 import com.example.community.dto.UserResponseDto;
 import com.example.community.entity.User;
@@ -9,8 +10,12 @@ import com.example.community.service.UserService;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -43,6 +48,16 @@ public class UserController { // 지금 생각해 보니 동시에 회원가입�
     // 응답 반환
     return ResponseEntity.ok(response);
 
+  }
+
+  @GetMapping("/mypage")
+  public ResponseEntity<MyPageResponseDto> getMyPage(HttpSession session,
+      @PageableDefault(size = 5, sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+
+    Long userId = (Long) session.getAttribute("loginUser");
+
+    MyPageResponseDto response = userService.getMyPage(userId, pageable);
+    return ResponseEntity.ok(response);
   }
 
 

--- a/src/main/java/com/example/community/dto/MyPageBoardDto.java
+++ b/src/main/java/com/example/community/dto/MyPageBoardDto.java
@@ -1,0 +1,22 @@
+package com.example.community.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MyPageBoardDto {
+
+  private Long boardId;
+  private String title;
+  private LocalDateTime created_At;
+  private int views;
+  private String message;
+
+
+}

--- a/src/main/java/com/example/community/dto/MyPageCommentDto.java
+++ b/src/main/java/com/example/community/dto/MyPageCommentDto.java
@@ -1,0 +1,22 @@
+package com.example.community.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MyPageCommentDto {
+
+  private Long commentId;
+  private String boardTitle;
+  private String content;
+  private LocalDateTime created_At;
+  private String message;
+
+
+}

--- a/src/main/java/com/example/community/dto/MyPageResponseDto.java
+++ b/src/main/java/com/example/community/dto/MyPageResponseDto.java
@@ -1,0 +1,19 @@
+package com.example.community.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class MyPageResponseDto {
+
+  private String message; // 마이페이지 조회 성공 메시지
+  private List<MyPageBoardDto> boards;
+  private List<MyPageCommentDto> comments;
+
+}

--- a/src/main/java/com/example/community/entity/Board.java
+++ b/src/main/java/com/example/community/entity/Board.java
@@ -1,0 +1,63 @@
+package com.example.community.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Table(name = "board")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Board {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, length = 200)
+  private String title;
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String content;
+
+  @Column(nullable = false)
+  @Builder.Default
+  private int views = 0;
+
+  @CreationTimestamp
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @UpdateTimestamp
+  @Column(nullable = false)
+  private LocalDateTime updatedAt;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
+  @Builder.Default
+  private List<Comment> comments = new ArrayList<>();
+
+
+}

--- a/src/main/java/com/example/community/entity/Comment.java
+++ b/src/main/java/com/example/community/entity/Comment.java
@@ -1,0 +1,61 @@
+package com.example.community.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Table(name = "comment")
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Comment {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false , columnDefinition = "TEXT")
+  private String content;
+
+  @CreationTimestamp
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  // N : 1
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  // N : 1
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "board_id", nullable = false)
+  private Board board;
+
+  // N : 1
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "parent_id")
+  private Comment parent;
+
+  // 1 : N
+  @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+  @Builder.Default
+  private List<Comment> children = new ArrayList<>();
+}

--- a/src/main/java/com/example/community/exception/UnauthorizedAccessException.java
+++ b/src/main/java/com/example/community/exception/UnauthorizedAccessException.java
@@ -1,0 +1,11 @@
+package com.example.community.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UnauthorizedAccessException extends BusinessException {
+
+  public UnauthorizedAccessException(String message) {
+
+    super(message, HttpStatus.UNAUTHORIZED);
+  }
+}

--- a/src/main/java/com/example/community/repository/BoardRepository.java
+++ b/src/main/java/com/example/community/repository/BoardRepository.java
@@ -1,0 +1,14 @@
+package com.example.community.repository;
+
+import com.example.community.entity.Board;
+import com.example.community.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+
+  // 유저가 작성한 게시글 (페이징)
+  Page<Board> findByUser(User user, Pageable pageable);
+
+}

--- a/src/main/java/com/example/community/repository/CommentRepository.java
+++ b/src/main/java/com/example/community/repository/CommentRepository.java
@@ -1,0 +1,14 @@
+package com.example.community.repository;
+
+import com.example.community.entity.Comment;
+import com.example.community.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+  // 유저가 작성한 댓글 (페이징)
+  Page<Comment> findByUser(User user, Pageable pageable);
+
+}

--- a/src/main/java/com/example/community/service/UserService.java
+++ b/src/main/java/com/example/community/service/UserService.java
@@ -2,18 +2,29 @@ package com.example.community.service;
 
 import com.example.community.dto.LoginRequestDto;
 import com.example.community.dto.LoginResponseDto;
+import com.example.community.dto.MyPageBoardDto;
+import com.example.community.dto.MyPageCommentDto;
+import com.example.community.dto.MyPageResponseDto;
 import com.example.community.dto.UserRequestDto;
 import com.example.community.dto.UserResponseDto;
+import com.example.community.entity.Board;
+import com.example.community.entity.Comment;
 import com.example.community.entity.User;
 import com.example.community.enums.Role;
 import com.example.community.exception.DuplicateNickNameException;
 import com.example.community.exception.DuplicateUserIdException;
 import com.example.community.exception.InvalidLoginPasswordException;
 import com.example.community.exception.InvalidPasswordException;
+import com.example.community.exception.UnauthorizedAccessException;
 import com.example.community.exception.UserNotFoundException;
+import com.example.community.repository.BoardRepository;
+import com.example.community.repository.CommentRepository;
 import com.example.community.repository.UserRepository;
 import com.example.community.util.PasswordValidator;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -21,7 +32,10 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
   private final UserRepository userRepository;
+  private final BoardRepository boardRepository;
+  private final CommentRepository commentRepository;
 
+  // 회원가입
   public UserResponseDto signup(UserRequestDto requestDto) {
 
     validateUserId(requestDto.getUserId());
@@ -48,6 +62,7 @@ public class UserService {
 
   }
 
+  // 로그인
   public LoginResponseDto login(LoginRequestDto requestDto) {
 
     User user = userRepository.findByUserId(requestDto.getUserId())
@@ -65,6 +80,58 @@ public class UserService {
         .message("로그인 성공!")
         .build();
 
+  }
+
+  // 마이페이지
+  public MyPageResponseDto getMyPage(Long userId, Pageable pageable) {
+
+    // 로그인 여부 검증하고
+    validateLoginUser(userId);
+
+    // 유저 존재 여부 검증 -> db와 세션 불일치 가능성 있기 때문
+    User user = findUserById(userId);
+
+    Page<Board> boardPage = boardRepository.findByUser(user, pageable);
+    List<MyPageBoardDto> boardDtos = boardPage.stream()
+        .map(board -> MyPageBoardDto.builder()
+            .boardId(board.getId())
+            .title(board.getTitle())
+            .views(board.getViews())
+            .created_At(board.getCreatedAt())
+            .build())
+        .toList();
+
+    Page<Comment> commentPage = commentRepository.findByUser(user, pageable);
+    List<MyPageCommentDto> commentDtos = commentPage.stream()
+        .map(comment -> MyPageCommentDto.builder()
+            .commentId(comment.getId())
+            .boardTitle(comment.getBoard().getTitle())
+            .content(comment.getContent())
+            .created_At(comment.getCreatedAt())
+            .build())
+        .toList();
+
+    String message =
+        (boardDtos.isEmpty() && commentDtos.isEmpty()) ? "작성한 글이나 댓글이 없습니다." : "마이페이지 조회 성공";
+
+    return MyPageResponseDto.builder()
+        .message(message)
+        .boards(boardDtos)
+        .comments(commentDtos)
+        .build();
+  }
+
+  // 로그인 여부 확인
+  private void validateLoginUser(Long userId) {
+    if (userId == null) {
+      throw new UnauthorizedAccessException("로그인이 필요한 서비스 입니다.");
+    }
+  }
+
+  // 유저 존재 여부 확인
+  private User findUserById(Long userId) {
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new UserNotFoundException("마이페이지 조회 실패 : 해당 유저가 존재하지 않습니다."));
   }
 
   // 아이디 중복 예외 메서드 분리

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,6 @@ spring.datasource.username=root
 spring.datasource.password=0216Alswjd2@@
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
-spring.jap.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
 - 회원가입/로그인 기능까지만 구현되어 있었음
 - 유저가 작성한 게시글/댓글을 확인할 수 있는 기능 없음

**TO-BE**
 - 마이페이지 API 추가
   - 로그인한 유저만 접근 가능 (세션 기반)
   - 유저가 작성한 게시글/댓글 조회 기능 구현
   - 게시글/댓글은 각각 5개 단위 페이징 처리, 최신순으로 정렬
   - 게시글 없을 시 "작성한 글이나 댓글이 없습니다."  메시지 반환
  
 - ddl-auto : update 으로 변경 
 - Board , Comment 엔티티 , Repository 생성
 
 1. DTO 추가
   - MyPageResponseDto : 마이페이지 전체 응답 객체 (메시지 + 게시글/댓글 목록)
   - MyPageBoardDto : 게시글 조회 전용 DTO
   - MyPageCommentDto : 댓글 조회 전용 DTO

 2. Repository 
    - BoardRepository.findByUser(User, Pageable)
    - CommentRepository.findByUser(User, pageable)
    -> 유저가 작성한 게시글/댓글 조회 쿼리 메서드 구현

 3. Service
   - UserService.getMyPage(Long userId, Pageable pageable)
      ㄴ 로그인 여부 검증
      ㄴ DB 유저 존재 여부 확인
      ㄴ 게시글/댓글 조회 후 DTO 변환
      ㄴ 응답 메시지 설정

 4. controller
    - UserController.getMyPage()
       ㄴ 로그인 세션에서 userId 추출
       ㄴ UserService.getMyPage() 호출
       ㄴ ResponseEntity<MyPageResponseDto> 응답

 5. 예외처리
    -  로그인 하지 않은 사용자가 접근 시 -> UnauthorizedAccessException("로그인이 필요한 서비스 입니다.")
    - DB에 유저가 존재하지 않을 경우 -> UserNotFoundException("마이페이지 조회 실패 : 해당 유저가 존재하지 않습니다.")
    - GlobalExceptionHandler 에서 일괄처리

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [O] API 테스트  (Postman 사용)
  1. 로그인하지 않은 상태에서 호출 시 401 Unauthorized 응답 확인
  2. 게시글/댓글이 없는 경우 "작성한 글이나 댓글이 없습니다." 메시지 반환 확인
