### PR TITLE
게시글 목록 조회 기능 추가

### DIFF
--- a/src/main/java/com/example/community/controller/BoardController.java
+++ b/src/main/java/com/example/community/controller/BoardController.java
@@ -1,17 +1,24 @@
 package com.example.community.controller;
 
+import com.example.community.dto.BoardListResponseDto;
 import com.example.community.dto.BoardRequestDto;
 import com.example.community.dto.BoardResponseDto;
+import com.example.community.enums.SortType;
 import com.example.community.exception.InvalidBoardException;
 import com.example.community.service.BoardService;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -36,6 +43,14 @@ public class BoardController {
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
+  @GetMapping("/listAll")
+  public ResponseEntity<BoardListResponseDto> getBoardList(
+      @PageableDefault(size = 5, sort = "createdAt", direction = Direction.DESC) Pageable pageable,
+      @RequestParam(defaultValue = "CREATED_AT") SortType sortBy) {
+
+    BoardListResponseDto response = boardService.getBoardList(pageable, sortBy);
+    return ResponseEntity.ok(response);
+  }
 
 
 }

--- a/src/main/java/com/example/community/dto/BoardListDto.java
+++ b/src/main/java/com/example/community/dto/BoardListDto.java
@@ -1,0 +1,19 @@
+package com.example.community.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class BoardListDto {
+
+  private Long id;
+  private String title;
+  private String nickName;
+  private int views;
+  private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/example/community/dto/BoardListResponseDto.java
+++ b/src/main/java/com/example/community/dto/BoardListResponseDto.java
@@ -1,0 +1,15 @@
+package com.example.community.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class BoardListResponseDto {
+
+  Page<BoardListDto> boardList;
+
+}

--- a/src/main/java/com/example/community/enums/SortType.java
+++ b/src/main/java/com/example/community/enums/SortType.java
@@ -1,0 +1,18 @@
+package com.example.community.enums;
+
+public enum SortType {
+  CREATED_AT("createdAt"),
+  VIEWS("views");
+
+  private final String field;
+
+  SortType(String field) {
+    this.field = field;
+  }
+
+  public String getField() {
+    return field;
+  }
+
+
+}

--- a/src/main/java/com/example/community/repository/BoardRepository.java
+++ b/src/main/java/com/example/community/repository/BoardRepository.java
@@ -11,4 +11,6 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
   // 유저가 작성한 게시글 (페이징)
   Page<Board> findByUser(User user, Pageable pageable);
 
+  Page<Board> findAll(Pageable pageable);
+
 }

--- a/src/main/java/com/example/community/service/BoardService.java
+++ b/src/main/java/com/example/community/service/BoardService.java
@@ -1,14 +1,22 @@
 package com.example.community.service;
 
+import com.example.community.dto.BoardListDto;
+import com.example.community.dto.BoardListResponseDto;
 import com.example.community.dto.BoardRequestDto;
 import com.example.community.dto.BoardResponseDto;
 import com.example.community.entity.Board;
 import com.example.community.entity.User;
+import com.example.community.enums.SortType;
 import com.example.community.exception.InvalidBoardException;
 import com.example.community.exception.UserNotFoundException;
 import com.example.community.repository.BoardRepository;
 import com.example.community.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -46,16 +54,40 @@ public class BoardService {
         .build();
   }
 
-  private void validateBoard(BoardRequestDto requestDto){
-    if(requestDto.getTitle() == null || requestDto.getTitle().trim().isEmpty()){
+  public BoardListResponseDto getBoardList(Pageable pageable, SortType sortBy) {
+
+    PageRequest pageRequest = PageRequest.of(
+        pageable.getPageNumber(),
+        pageable.getPageSize(),
+        Sort.by(Direction.DESC, sortBy.getField())
+    );
+
+    Page<Board> boardPage = boardRepository.findAll(pageRequest);
+
+    Page<BoardListDto> dtoPage = boardPage.map(board ->
+        BoardListDto.builder()
+            .id(board.getId())
+            .title(board.getTitle())
+            .nickName(board.getUser().getNickName())
+            .views(board.getViews())
+            .createdAt(board.getCreatedAt())
+            .build()
+    );
+
+    return new BoardListResponseDto(dtoPage);
+
+  }
+
+  private void validateBoard(BoardRequestDto requestDto) {
+    if (requestDto.getTitle() == null || requestDto.getTitle().trim().isEmpty()) {
       throw new InvalidBoardException("게시글 제목이 비어있습니다.");
     }
 
-    if(requestDto.getContent() == null || requestDto.getContent().trim().isEmpty()){
+    if (requestDto.getContent() == null || requestDto.getContent().trim().isEmpty()) {
       throw new InvalidBoardException("게시글 내용이 비어있습니다.");
     }
 
-
   }
+
 
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
 - 게시글 목록 조회 기능 없음
 - 정렬 기준 String sortBy 로 받아서 유효하지 않은 값이 들어와도 실행 됨
**TO-BE**
 - 게시글 목록 조회 API 추가 (GET /boards/listAll)
 - 정렬 조건을 enum(SortType) 기반으로 관리 -> 안정성과 가독성 확보
 - 정렬 조건은 CREATED_AT / VIEWS 두 가지 허용

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [O] API 테스트  postman 테스트