### PR TITLE
특정 게시글 조회 기능

### DIFF
--- a/src/main/java/com/example/community/controller/BoardController.java
+++ b/src/main/java/com/example/community/controller/BoardController.java
@@ -1,5 +1,6 @@
 package com.example.community.controller;
 
+import com.example.community.dto.BoardDetailResponseDto;
 import com.example.community.dto.BoardListResponseDto;
 import com.example.community.dto.BoardRequestDto;
 import com.example.community.dto.BoardResponseDto;
@@ -15,6 +16,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -50,6 +52,15 @@ public class BoardController {
 
     BoardListResponseDto response = boardService.getBoardList(pageable, sortBy);
     return ResponseEntity.ok(response);
+  }
+
+  @GetMapping("/{boardId}")
+  public ResponseEntity<BoardDetailResponseDto> getBoardDetail(@PathVariable Long boardId){
+
+    BoardDetailResponseDto response = boardService.getBoardDetail(boardId);
+
+    return ResponseEntity.ok(response);
+
   }
 
 

--- a/src/main/java/com/example/community/dto/BoardDetailResponseDto.java
+++ b/src/main/java/com/example/community/dto/BoardDetailResponseDto.java
@@ -1,0 +1,23 @@
+package com.example.community.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class BoardDetailResponseDto {
+
+  private Long id;
+  private String title;
+  private String content;
+  private String nickName;
+  private int views;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/example/community/entity/Board.java
+++ b/src/main/java/com/example/community/entity/Board.java
@@ -59,5 +59,9 @@ public class Board {
   @Builder.Default
   private List<Comment> comments = new ArrayList<>();
 
+  public void increaseViews(){
+    this.views += 1;
+  }
+
 
 }

--- a/src/main/java/com/example/community/exception/BoardNotFoundException.java
+++ b/src/main/java/com/example/community/exception/BoardNotFoundException.java
@@ -1,0 +1,10 @@
+package com.example.community.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class BoardNotFoundException extends BusinessException {
+
+  public BoardNotFoundException(String message) {
+    super(message, HttpStatus.NOT_FOUND);
+  }
+}

--- a/src/main/java/com/example/community/repository/BoardRepository.java
+++ b/src/main/java/com/example/community/repository/BoardRepository.java
@@ -2,9 +2,14 @@ package com.example.community.repository;
 
 import com.example.community.entity.Board;
 import com.example.community.entity.User;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
@@ -13,4 +18,7 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
   Page<Board> findAll(Pageable pageable);
 
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select b from Board b where b.id = :boardId")
+  Optional<Board> findByIdWithLock(@Param("boardId") Long boardId);
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
 - 특정 게시글 조회 기능이 구현되지 않음.
 - 다중 사용자가 동시에 특정 게시글을 조회할 경우, 조회수(views) 증가 값이 유실되는 동시성 문제 발생 가능

**TO-BE**
 - BoardRepository 에 비관적 락 기반 조회 메서드 추가
 - BoardService 에서 트랜잭션 단위로 게시글 조회 시 락을 걸고 조회수 증가 처리.
 - Board 엔티티에 increaseViews() 메서드 추가하여 조회수 증가 로직을 응집
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [O] API 테스트 