### PR TITLE
댓글 작성 기능 및 댓글 조회 기능

### DIFF
--- a/src/main/java/com/example/community/controller/BoardController.java
+++ b/src/main/java/com/example/community/controller/BoardController.java
@@ -55,9 +55,10 @@ public class BoardController {
   }
 
   @GetMapping("/{boardId}")
-  public ResponseEntity<BoardDetailResponseDto> getBoardDetail(@PathVariable Long boardId){
+  public ResponseEntity<BoardDetailResponseDto> getBoardDetail(@PathVariable Long boardId,
+      @PageableDefault(size = 5, sort = "createdAt", direction = Direction.DESC) Pageable pageable){
 
-    BoardDetailResponseDto response = boardService.getBoardDetail(boardId);
+    BoardDetailResponseDto response = boardService.getBoardDetail(boardId,pageable);
 
     return ResponseEntity.ok(response);
 

--- a/src/main/java/com/example/community/controller/CommentController.java
+++ b/src/main/java/com/example/community/controller/CommentController.java
@@ -1,0 +1,56 @@
+package com.example.community.controller;
+
+import com.example.community.dto.CommentRequestDto;
+import com.example.community.dto.CommentResponseDto;
+import com.example.community.exception.UnauthorizedAccessException;
+import com.example.community.service.CommentService;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/boards/{boardId}/comments")
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+
+  private final CommentService commentService;
+
+  // 댓글 작성
+  @PostMapping
+  public ResponseEntity<CommentResponseDto> createdComment(@PathVariable Long boardId,
+      @Valid @RequestBody CommentRequestDto requestDto,
+      HttpSession session) {
+
+    Long userId = (Long) session.getAttribute("loginUser");
+    if (userId == null) {
+      throw new UnauthorizedAccessException("로그인이 필요한 서비스 입니다.");
+    }
+
+    CommentResponseDto response = commentService.createdComment(boardId, userId, requestDto);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+
+  }
+
+  // 댓글 조회
+  @GetMapping
+  public ResponseEntity<Page<CommentResponseDto>> getComments(
+      @PathVariable Long boardId,
+      @PageableDefault(size = 5, sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+
+    Page<CommentResponseDto> response = commentService.getComments(boardId, pageable);
+    return ResponseEntity.ok(response);
+  }
+
+}

--- a/src/main/java/com/example/community/dto/BoardDetailResponseDto.java
+++ b/src/main/java/com/example/community/dto/BoardDetailResponseDto.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -19,5 +20,8 @@ public class BoardDetailResponseDto {
   private int views;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
+
+  // 댓글 계층 구조 추가
+  private Page<CommentResponseDto> comments;
 
 }

--- a/src/main/java/com/example/community/dto/CommentRequestDto.java
+++ b/src/main/java/com/example/community/dto/CommentRequestDto.java
@@ -1,0 +1,16 @@
+package com.example.community.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class CommentRequestDto {
+
+  private String content;
+
+  private Long parentId;
+
+}

--- a/src/main/java/com/example/community/dto/CommentResponseDto.java
+++ b/src/main/java/com/example/community/dto/CommentResponseDto.java
@@ -1,0 +1,41 @@
+package com.example.community.dto;
+
+import com.example.community.entity.Comment;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class CommentResponseDto {
+
+  private Long id;
+  private String content;
+  private String nickName;
+  private LocalDateTime createdAt;
+  private Long parentId;
+
+  @Builder.Default
+  private List<CommentResponseDto> children = new ArrayList<>();
+
+  public static CommentResponseDto from(Comment comment) {
+
+    return CommentResponseDto.builder()
+        .id(comment.getId())
+        .content(comment.getContent())
+        .nickName(comment.getUser().getNickName())
+        .createdAt(comment.getCreatedAt())
+        .parentId(comment.getParent() != null ? comment.getParent().getId() : null)
+        .children(comment.getChildren().stream()
+            .map(CommentResponseDto::from)
+            .toList())
+        .build();
+  }
+
+}

--- a/src/main/java/com/example/community/exception/CommentNotFoundException.java
+++ b/src/main/java/com/example/community/exception/CommentNotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.community.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class CommentNotFoundException extends BusinessException {
+
+  public CommentNotFoundException(String message) {
+
+    super(message, HttpStatus.NOT_FOUND);
+  }
+}

--- a/src/main/java/com/example/community/exception/InvalidCommentException.java
+++ b/src/main/java/com/example/community/exception/InvalidCommentException.java
@@ -1,0 +1,10 @@
+package com.example.community.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidCommentException extends BusinessException {
+
+  public InvalidCommentException(String message) {
+    super(message, HttpStatus.BAD_REQUEST);
+  }
+}

--- a/src/main/java/com/example/community/repository/CommentRepository.java
+++ b/src/main/java/com/example/community/repository/CommentRepository.java
@@ -1,5 +1,7 @@
 package com.example.community.repository;
 
+import com.example.community.dto.CommentResponseDto;
+import com.example.community.entity.Board;
 import com.example.community.entity.Comment;
 import com.example.community.entity.User;
 import org.springframework.data.domain.Page;
@@ -10,5 +12,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
   // 유저가 작성한 댓글 (페이징)
   Page<Comment> findByUser(User user, Pageable pageable);
+
+  Page<Comment> findByBoard(Board board, Pageable pageable);
+
+  Page<Comment> findByBoardAndParentIsNull(Board board, Pageable pageable);
 
 }

--- a/src/main/java/com/example/community/service/CommentService.java
+++ b/src/main/java/com/example/community/service/CommentService.java
@@ -1,0 +1,86 @@
+package com.example.community.service;
+
+import com.example.community.dto.CommentRequestDto;
+import com.example.community.dto.CommentResponseDto;
+import com.example.community.entity.Board;
+import com.example.community.entity.Comment;
+import com.example.community.entity.User;
+import com.example.community.exception.BoardNotFoundException;
+import com.example.community.exception.CommentNotFoundException;
+import com.example.community.exception.InvalidCommentException;
+import com.example.community.exception.UserNotFoundException;
+import com.example.community.repository.BoardRepository;
+import com.example.community.repository.CommentRepository;
+import com.example.community.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+  private final CommentRepository commentRepository;
+  private final BoardRepository boardRepository;
+  private final UserRepository userRepository;
+
+  @Transactional
+  public CommentResponseDto createdComment(Long boardId, Long userId,
+      CommentRequestDto requestDto) {
+
+    // 게시글 검증
+    Board board = boardRepository.findById(boardId)
+        .orElseThrow(() -> new BoardNotFoundException("해당 게시글이 존재하지 않습니다."));
+
+    // 유저 검증
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new UserNotFoundException("해당 유저가 존재하지 않습니다."));
+
+    // 부모 댓글 검증
+    Comment parent = null;
+    if (requestDto.getParentId() != null) {
+      parent = commentRepository.findById(requestDto.getParentId())
+          .orElseThrow(() -> new CommentNotFoundException("해당 상위 댓글은 존재하지 않습니다."));
+
+      if (parent.getChildren().size() >= 10) {
+        throw new InvalidCommentException("대댓글은 최대 10개까지만 작성 가능합니다.");
+      }
+    }
+
+    // 댓글 생성
+    Comment comment = Comment.builder()
+        .content(requestDto.getContent())
+        .user(user)
+        .board(board)
+        .parent(parent)
+        .build();
+
+    Comment saved = commentRepository.save(comment);
+
+    return CommentResponseDto.builder()
+        .id(saved.getId())
+        .content(saved.getContent())
+        .nickName(user.getNickName())
+        .createdAt(saved.getCreatedAt())
+        .parentId(parent != null ? parent.getId() : null)
+        .build();
+  }
+
+  // 댓글 목록 조회
+  @Transactional(readOnly = true)
+  public Page<CommentResponseDto> getComments(Long boardId, Pageable pageable) {
+
+    Board board = boardRepository.findById(boardId)
+        .orElseThrow(() -> new BoardNotFoundException("게시글을 찾을 수 없습니다."));
+
+    // 루트 댓글만 페이징으로 가져옴
+    Page<Comment> rootComments = commentRepository.findByBoardAndParentIsNull(board, pageable);
+
+    // 각 루트 댓글 + children 트리 구조로 변환
+    return rootComments.map(CommentResponseDto::from);
+  }
+
+
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
 - 게시글 상세 조회 시 댓글 정보 없음
 - 댓글 조회는 단순 리스트 구조만 고려
 - 댓글 작성 시 예외처리 단순
**TO-BE**
 - 댓글 작성 기능 추가
    - 본문(content), 부모 댓글 ID (parentId, 선택) 를 받아 댓글/대댓글 작성 가능
    - 게시글, 유저, 부모 댓글 존재 여부 검증 
    - content 미입력 시 예외 발생 처리
 - 댓글 조회 기능 개선
    - 루트 댓글만 페이징 처리 (5개 단위)
    - 각 루트 댓글에 children 으로 대댓글 트리 구조 포함
    - Board 상세 조회 시 댓글 일부도 함께 반환
 - BoardService -> 댓글 조회 시 CommentService 위임 

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [O] API 테스트
  - 게시글에 댓글 작성 성공
  - 대댓글 작성 시 parentId 정상 반영
  - 게시글 상세 조회 시 댓글 함께 반환