### PR TITLE
Feature/redis view cache

### DIFF
--- a/src/main/java/com/example/community/config/JacksonConfig.java
+++ b/src/main/java/com/example/community/config/JacksonConfig.java
@@ -1,0 +1,4 @@
+package com.example.community.config;
+
+public class JacksonConfig {
+}

--- a/src/main/java/com/example/community/config/JacksonConfig.java
+++ b/src/main/java/com/example/community/config/JacksonConfig.java
@@ -1,4 +1,20 @@
 package com.example.community.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
 public class JacksonConfig {
+
+  @Bean
+  public ObjectMapper objectMapper(){
+    ObjectMapper om = new ObjectMapper();
+    om.registerModule(new JavaTimeModule());
+    om.disable(SeriㅌalizationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    return om;
+  }
+
 }

--- a/src/main/java/com/example/community/config/RedisConfig.java
+++ b/src/main/java/com/example/community/config/RedisConfig.java
@@ -37,8 +37,8 @@ public class RedisConfig {
   }
 
   @Bean
-  public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory){
-    RedisTemplate<String, Object> template = new RedisTemplate<>();
+  public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory){
+    RedisTemplate<String, String> template = new RedisTemplate<>();
     template.setConnectionFactory(redisConnectionFactory);
     // 키와 값 모두 String 으로 변환
     template.setKeySerializer(new StringRedisSerializer());

--- a/src/main/java/com/example/community/config/SchedulerConfig.java
+++ b/src/main/java/com/example/community/config/SchedulerConfig.java
@@ -1,0 +1,10 @@
+package com.example.community.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+
+}

--- a/src/main/java/com/example/community/controller/BoardController.java
+++ b/src/main/java/com/example/community/controller/BoardController.java
@@ -5,6 +5,7 @@ import com.example.community.dto.board.BoardListResponseDto;
 import com.example.community.dto.board.BoardRequestDto;
 import com.example.community.dto.board.BoardResponseDto;
 import com.example.community.enums.SortType;
+import com.example.community.jwt.JwtUserAuthentication;
 import com.example.community.service.BoardService;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
@@ -15,6 +16,8 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -32,14 +35,16 @@ public class BoardController {
 
   @PostMapping("/post")
   public ResponseEntity<BoardResponseDto> createdBoard(
-      @Valid @RequestBody BoardRequestDto requestDto,
-      HttpSession session) {
+      @Valid @RequestBody BoardRequestDto requestDto) {
 
-    Long userId = (Long) session.getAttribute("loginUser");
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-    if (userId == null) {
+    if (authentication == null || !(authentication instanceof JwtUserAuthentication)) {
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     }
+
+    JwtUserAuthentication jwtUserAuthentication = (JwtUserAuthentication) authentication;
+    Long userId = jwtUserAuthentication.getUserPk();
 
     BoardResponseDto response = boardService.createBoard(userId, requestDto);
     return ResponseEntity.status(HttpStatus.CREATED).body(response);

--- a/src/main/java/com/example/community/controller/UserController.java
+++ b/src/main/java/com/example/community/controller/UserController.java
@@ -3,6 +3,7 @@ package com.example.community.controller;
 import com.example.community.dto.user.MyPageResponseDto;
 import com.example.community.dto.user.UserRequestDto;
 import com.example.community.dto.user.UserResponseDto;
+import com.example.community.exception.UnauthorizedAccessException;
 import com.example.community.jwt.JwtUserAuthentication;
 import com.example.community.service.UserService;
 import jakarta.validation.Valid;
@@ -12,7 +13,9 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -41,10 +44,17 @@ public class UserController { // 지금 생각해 보니 동시에 회원가입�
    */
   @GetMapping("/mypage")
   public ResponseEntity<MyPageResponseDto> getMyPage(
-      @AuthenticationPrincipal JwtUserAuthentication jwtUserAuthentication,
       @PageableDefault(size = 5, sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
 
-    Long userPk = jwtUserAuthentication.getUserPk(); // JWT 에서 PK 추출
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    if (authentication == null || !(authentication instanceof JwtUserAuthentication)) {
+      throw new UnauthorizedAccessException("로그인이 필요한 서비스입니다.");
+    }
+
+    JwtUserAuthentication jwtUserAuthentication = (JwtUserAuthentication) authentication;
+    Long userPk = jwtUserAuthentication.getUserPk();
+
     MyPageResponseDto response = userService.getMyPage(userPk, pageable);
     return ResponseEntity.ok(response);
   }

--- a/src/main/java/com/example/community/entity/Board.java
+++ b/src/main/java/com/example/community/entity/Board.java
@@ -71,9 +71,4 @@ public class Board {
   @Builder.Default
   private List<Comment> comments = new ArrayList<>();
 
-  public void increaseViews(){
-    this.views += 1;
-  }
-
-
 }

--- a/src/main/java/com/example/community/exception/CacheDeserializeException.java
+++ b/src/main/java/com/example/community/exception/CacheDeserializeException.java
@@ -1,7 +1,10 @@
 package com.example.community.exception;
 
-public class CacheDeserializeException extends RuntimeException {
+import org.springframework.http.HttpStatus;
+
+public class CacheDeserializeException extends  BusinessException {
+
   public CacheDeserializeException(String message) {
-    super(message);
+    super(message, HttpStatus.INTERNAL_SERVER_ERROR);
   }
 }

--- a/src/main/java/com/example/community/exception/CacheDeserializeException.java
+++ b/src/main/java/com/example/community/exception/CacheDeserializeException.java
@@ -1,0 +1,7 @@
+package com.example.community.exception;
+
+public class CacheDeserializeException extends RuntimeException {
+  public CacheDeserializeException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/example/community/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/community/exception/GlobalExceptionHandler.java
@@ -2,12 +2,16 @@ package com.example.community.exception;
 
 
 import com.example.community.dto.common.ErrorResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -38,7 +42,8 @@ public class GlobalExceptionHandler {
 
   // 요청 본문이 비었거나 JSON 파싱 실패
   @ExceptionHandler(HttpMessageNotReadableException.class)
-  public ResponseEntity<ErrorResponse> handleHttpMessageNotReadable(HttpMessageNotReadableException e){
+  public ResponseEntity<ErrorResponse> handleHttpMessageNotReadable(
+      HttpMessageNotReadableException e) {
     ErrorResponse response = ErrorResponse.builder()
         .code("INVALID_REQUEST")
         .message("요청 본문이 비었습니다.")
@@ -47,13 +52,40 @@ public class GlobalExceptionHandler {
     return ResponseEntity.badRequest().body(response);
   }
 
+  // JSON 직렬화/역직렬화 오류
+  @ExceptionHandler(JsonProcessingException.class)
+  public ResponseEntity<ErrorResponse> handleJsonProcession(JsonProcessingException e) {
+    log.error("JSON parsing error", e);
+
+    ErrorResponse response = ErrorResponse.builder()
+        .code("JSON_PARSE_ERROR")
+        .message("데이터 처리 중 오류가 발생했습니다.")
+        .build();
+
+    return ResponseEntity.internalServerError().body(response);
+  }
+
+  // Redis 연결 오류
+  @ExceptionHandler(RedisConnectionFailureException.class)
+  public ResponseEntity<ErrorResponse> handleRedis(RedisConnectionFailureException e) {
+    log.error("Redis connection failed", e);
+
+    ErrorResponse response = ErrorResponse.builder()
+        .code("REDIS_UNAVAILABLE")
+        .message("캐시 서버와 연결할 수 없습니다. 잠시 후 다시 시도해주세요.")
+        .build();
+
+    return ResponseEntity.status(503).body(response);
+  }
+
   // 그 외 모든 예외 처리
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ErrorResponse> handlerException(Exception e) {
-    e.printStackTrace();
+
+    log.error("Unexcepted error", e);
     ErrorResponse response = ErrorResponse.builder()
         .code("INTERNAL_SERVER_ERROR")
-        .message(e.getMessage())
+        .message("서버 오류가 발생했습니다.")
         .build();
 
     return ResponseEntity.internalServerError().body(response);

--- a/src/main/java/com/example/community/jwt/TokenBlacklistService.java
+++ b/src/main/java/com/example/community/jwt/TokenBlacklistService.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TokenBlacklistService {
 
-  private final RedisTemplate<String, Object> redisTemplate;
+  private final RedisTemplate<String, String> redisTemplate;
 
   // 로그아웃 시 AccessToken 블랙리스트 등록
   // TTL (Time To Live)은 토큰의 남은 만료 시간만큼 지정
@@ -22,7 +22,7 @@ public class TokenBlacklistService {
 
   // AccessToken이 블랙리스트에 등록되었는지 확인
   public boolean isBlacklisted(String token) {
-    return redisTemplate.hasKey(token);
+    return redisTemplate.hasKey("BL: " + token);
   }
 
   // RefreshToken 저장 (PK 기준)

--- a/src/main/java/com/example/community/repository/BoardRepository.java
+++ b/src/main/java/com/example/community/repository/BoardRepository.java
@@ -2,12 +2,10 @@ package com.example.community.repository;
 
 import com.example.community.entity.Board;
 import com.example.community.entity.User;
-import jakarta.persistence.LockModeType;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -19,14 +17,6 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
   // 최신순, 조회순 정렬은 pageable + SortType enum 기반
   Page<Board> findAll(Pageable pageable);
 
-  // 비관적 락을 통한 동시성 제어 (조회 수 증가 시)
-  @Lock(LockModeType.PESSIMISTIC_WRITE)
-  @Query("select b from Board b where b.id = :boardId")
-  Optional<Board> findByIdWithLock(@Param("boardId") Long boardId);
-
-  // 특정 게시글 제목 검색 (인덱스 : idx_board_title 활용)
-//  Page<Board> findByTitleContaining(String keyword, Pageable pageable);
-
   // 특정 게시글 작성자 닉네임 검색 (인덱스 : idx_user_nickname 활용)
   Page<Board> findByUserNickName(String nickName, Pageable pageable);
 
@@ -37,5 +27,14 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
   Page<Board> findByTitleStartingWith(String keyword, Pageable pageable);
 
   Page<Board> findAllByOrderByViewsDesc(Pageable pageable);
+
+  /**
+   * Redis -> DB 배치 반영을 위한 조회수 업데이트
+   * Redis에 누적된 views 값을 DB에 반영
+   * viewSyncService 에서 1분 주기 실행
+   */
+  @Modifying
+  @Query("UPDATE Board b SET b.views = :views WHERE b.id = :boardId")
+  void updateViews(@Param("boardId") Long boardId , @Param("views") int views);
 
 }

--- a/src/main/java/com/example/community/service/BoardService.java
+++ b/src/main/java/com/example/community/service/BoardService.java
@@ -13,22 +13,29 @@ import com.example.community.exception.InvalidBoardException;
 import com.example.community.exception.UserNotFoundException;
 import com.example.community.repository.BoardRepository;
 import com.example.community.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class BoardService {
 
   private final UserRepository userRepository;
   private final BoardRepository boardRepository;
   private final CommentService commentService;
+  private final RedisTemplate<String, String> redisTemplate;
+  private final ObjectMapper objectMapper;
 
 
   // 게시글 작성
@@ -72,20 +79,46 @@ public class BoardService {
   }
 
   // 특정 게시글 조회
-  @Transactional
+  @Transactional(readOnly = true)
   public BoardDetailResponseDto getBoardDetail(Long boardId, Pageable pageable) {
-    // 1. 게시글 조회 (비관적 락 적용하기)
-    Board board = boardRepository.findByIdWithLock(boardId)
-        .orElseThrow(() -> new BoardNotFoundException("해당 게시글이 존재하지 않습니다."));
 
-    // 2. 조회수 증가
-    board.increaseViews();
+    final String cacheKey = "board:detail:" + boardId;
+    final String viewKey = "board:" + boardId + ":views";
 
-    // 댓글도 함께 조회 (트리구조 + 페이징)
+    // 1) 캐시 HIT 시도
+    String cached = redisTemplate.opsForValue().get(cacheKey);
+    if (cached != null) {
+      try {
+        BoardDetailResponseDto detailDto = objectMapper.readValue(cached,
+            BoardDetailResponseDto.class);
+        // 역직렬화 성공일 때만 카운트
+        redisTemplate.opsForValue().increment(viewKey);
+        return detailDto;
+      } catch (Exception e) {
+        // 캐시 손상/포맷 변경/워밍 레이스 -> 서비스는 DB 폴백
+        log.warn("Cache corrupted for key={}, fallback to DB", cacheKey, e);
+      }
+    }
+
+    // 2) 캐시 MISS 또는 손상 시 DB 조회
+    Board board = boardRepository.findById(boardId)
+        .orElseThrow(() -> new BoardNotFoundException("해당 게시글을 찾을 수 없습니다."));
+
     Page<CommentResponseDto> comments = commentService.getComments(boardId, pageable);
+    BoardDetailResponseDto detailResponse = BoardDetailResponseDto.from(board, comments);
 
-    return BoardDetailResponseDto.from(board, comments);
+    // 3) 캐시 저장 (실패해도 서비스 계속)
+    try {
+      String json = objectMapper.writeValueAsString(detailResponse);
+      redisTemplate.opsForValue().set(cacheKey, json, Duration.ofSeconds(30));
+    } catch (Exception e) {
+      log.warn("Cache serialization failed for key={}", cacheKey, e);
+    }
 
+    // 4) 조회수 증가 (Redis only)
+    redisTemplate.opsForValue().increment(viewKey);
+
+    return detailResponse;
   }
 
   private void validateBoard(BoardRequestDto requestDto) {

--- a/src/main/java/com/example/community/service/ViewSyncService.java
+++ b/src/main/java/com/example/community/service/ViewSyncService.java
@@ -1,0 +1,39 @@
+package com.example.community.service;
+
+import com.example.community.repository.BoardRepository;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ViewSyncService {
+
+  private final RedisTemplate<String, String> redisTemplate;
+  private final BoardRepository boardRepository;
+
+  @Scheduled(fixedRate = 60000) // 1분마다
+  @Transactional
+  public void syncViewCounts() {
+    Set<String> keys = redisTemplate.keys("board:*:views");
+
+    if (keys == null)
+      return;
+
+    for (String key : keys) {
+      Long boardId = Long.valueOf(key.split(":")[1]);
+      String count = redisTemplate.opsForValue().get(key);
+
+      if (count == null)
+        continue;
+
+      int views = Integer.parseInt(count);
+      boardRepository.updateViews(boardId, views);
+    }
+  }
+
+
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
 - 모든 게시글 조회 시 MariaDb 에 직접 접근하여 조회수를 즉시 업데이트 함
 - 다수의 요청이 동시에 발생하면 DB 부하 증가 및 잠금(lock) 경쟁 발생 가능
 - 캐시 미적용으로 동일한 게시글 조회 시 매번 DB 쿼리 실행
 - 조회수 증가와 상세 조회가 한 트랜잭션 내에서 이루어져 성능 저하 발생

**TO-BE**
 - Redis 기반의 **조회수 캐시 및 상세 캐시 로직 적용**
    - 게시글 상세 조회 시 Redis 캐시 ("board:detail:{id}")를 우선 조회 (Cache-Aside 전략)
    - 캐시가 존재하지 않을 경우 DB 조회 후 Redis에 TTL 30초로 캐싱
    - 조회수는 Redis INCR 연산("board:{id}:views") 으로 관리 (DB 부하 감소)
 - @Scheduled 가 적용된 "ViewSyncService" 를 통해 Redis -> DB 동기화를 **1분 주기 Write-Behind 방식** 수행
 - "BoardService" 내부 로직 리팩토링
    - 캐시 데이터 역직렬화 실패 시 자동 DB 폴백 처리
    - "ObjectMapper" 를 활용해 "BoardDetailResponseDto" JSON 변환
 - "CacheDeserializeException" 및 "GlobalExceptionHandler" 추가
    -> 캐시 직렬화/역직렬화 시 예외 발생 시 서비스 중단 없이 폴백 처리
 - "RedisConfig", "SchedulerConfig" , "JacksonConfig" 구성 클래스 Redis 직렬화 전력 및 스케줄러 활성화 설정 분리

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 